### PR TITLE
Create example_resubmit_CESM.sh

### DIFF
--- a/User_guides/example_resubmit_CESM.sh
+++ b/User_guides/example_resubmit_CESM.sh
@@ -1,0 +1,27 @@
+#! /bin/tcsh
+ 
+set vproj = 'B1850.f19_g17.example'  		# set the directory for your existing case
+set casepath = '/work/07931/dunyuliu/CESM2/cases/'  
+# set the directory for your existing case root.
+ 
+cd $casepath$vproj					# get into the case root directory
+ 
+./xmlchange JOB_WALLCLOCK_TIME=12:00:00   # Change wall clock time to 12 hours.
+ 
+./xmlquery STOP_OPTION,STOP_N 		# show stop options
+./xmlchange STOP_OPTION=nmonths,STOP_N=12 
+# change stop option to months and ask the code to stop after 12 months run. 
+# Pay attention to that no space is allowed between 'nmonths,STOP_N'.
+
+./xmlchange DOUT_S=FALSE 			
+# No short time archiving and writing out results. For productive runs and postprocessing
+# set the value to TRUE.
+ 
+./xmlchange RESUBMIT=3 
+# let CESM resubmit the job 3 times after the first run. A total of 4 runs will be
+# conducted. 
+
+./case.submit --resubmit-immediate			
+# submit a case to the HPC cluster. It is suggested to add a flag --resubmit-immediate to
+# submit all the jobs together with batch dependency. In this case, you don't need to
+# worry about unintended termination of your resubmission.  


### PR DESCRIPTION
Original Author: Dunyu Liu
Last modified: 03/24/2021 by Dunyu Liu

This document shows a shell script to resubmit a job for an existing CESM case. The example is for a model with the compset of B1850 and grid resolutions of f19_g17. For Lonestar5, you can copy the following script into a file with a name like example_resubmit_CESM.sh. To run the script with tcsh, type in a terminal ‘tcsh example_resubmit_CESM.sh’. For permission and access to the shared directory, please contact Dr. Geeta Persad via geeta.persad@jsg.utexas.edu.